### PR TITLE
Fix java.lang.NoClassDefFoundError com/github/weisj/jsvg/parser/SVGLoader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation "com.github.weisj:jsvg:${project.jsvg_parser}"
 
 	include "io.lindstrom:m3u8-parser:${project.m3u8_parser_version}"
+	include "com.github.weisj:jsvg:${project.jsvg_parser}"
 	include "org.bytedeco:javacv:${project.javacv_version}"
 	include "org.bytedeco:javacpp:${project.javacv_version}"
 	include "org.bytedeco:javacpp:${project.javacv_version}:linux-arm64"

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 
 	implementation "io.lindstrom:m3u8-parser:${project.m3u8_parser_version}"
 	implementation "org.bytedeco:javacv-platform:${project.javacv_version}"
+	implementation "com.github.weisj:jsvg:${project.jsvg_parser}"
 
 	include "io.lindstrom:m3u8-parser:${project.m3u8_parser_version}"
 	include "org.bytedeco:javacv:${project.javacv_version}"
@@ -45,7 +46,6 @@ dependencies {
 	include "org.bytedeco:ffmpeg:5.0-${project.javacv_version}:macosx-arm64"
 	include "org.bytedeco:ffmpeg:5.0-${project.javacv_version}:macosx-x86_64"
 	include "org.bytedeco:ffmpeg:5.0-${project.javacv_version}:windows-x86_64"
-
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 	fabric_version=0.94.1+1.20.4
 	m3u8_parser_version=0.22
 	javacv_version=1.5.7
+	jsvg_parser=1.4.0

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerManager.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerManager.java
@@ -57,10 +57,7 @@ public class DisplayLayerManager extends DisplayLayerMap<Object> {
     protected Object getLayerKey(Key key) {
         String path = key.uri().getPath();
         if (path.endsWith(".svg")) {
-            return new DisplayLayerSVGImage.SVGOptions(
-                key.display().getWidth(),
-                key.display().getHeight()
-            );
+            return svgMap.getLayerKey(key); // we need to call this somewhere.
         }
         return key.uri();
     }

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerManager.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerManager.java
@@ -11,7 +11,7 @@ import java.net.URI;
  * This class is responsible for caching and keeping the number of layer to the minimum.
  */
 @Environment(EnvType.CLIENT)
-public class DisplayLayerManager extends DisplayLayerMap<Object> {
+public class DisplayLayerManager extends DisplayLayerMap<URI> {
 
     /** Max cost for concurrent layers. */
     private static final int MAX_LAYERS_COST = 20 * 30;  // Approx 20 HLS layers.
@@ -25,9 +25,6 @@ public class DisplayLayerManager extends DisplayLayerMap<Object> {
     /** Time in nanoseconds (monotonic) of the last cleanup for unused layers. */
     private long lastCleanup = 0;
 
-    /** Used to handle SVG images. **/
-    private final DisplayLayerSVGMap svgMap = new DisplayLayerSVGMap(this.res); //TODO: probably change where this happens.
-    
     public DisplayLayerResources getResources() {
         return this.res;
     }
@@ -54,11 +51,7 @@ public class DisplayLayerManager extends DisplayLayerMap<Object> {
 
     @Override
     @NotNull
-    protected Object getLayerKey(Key key) {
-        String path = key.uri().getPath();
-        if (path.endsWith(".svg")) {
-            return svgMap.getLayerKey(key); // we need to call this somewhere.
-        }
+    protected URI getLayerKey(Key key) {
         return key.uri();
     }
 
@@ -77,7 +70,7 @@ public class DisplayLayerManager extends DisplayLayerMap<Object> {
             } else if (path.endsWith(".jpeg") || path.endsWith(".jpg") || path.endsWith(".bmp") || path.endsWith(".png")) {
                 return new DisplayLayerImage(key.uri(), this.res);
             } else if (path.endsWith(".svg")) {
-                return svgMap.getNewLayer(key);
+                return new DisplayLayerSVGMap(this.res);
             }
         }
 

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGImage.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGImage.java
@@ -57,7 +57,7 @@ public class DisplayLayerSVGImage extends DisplayLayerImage {
 			ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
 			ImageIO.write(image, "png", byteArrayOutputStream);
 			byte[] imageData = byteArrayOutputStream.toByteArray();
-			buf = ByteBuffer.allocateDirect(imageData.length);
+			buf = MemoryUtil.memAlloc(imageData.length);
 			buf.put(imageData);
 			buf.flip();
 
@@ -78,5 +78,16 @@ public class DisplayLayerSVGImage extends DisplayLayerImage {
 	}
 
 	public record SVGOptions(float width, float height) {
+	}
+
+	@Override
+	protected String makeLog(String message) {
+		if (this.options == null) {
+			// Options should not be null in normal condition, but this actually happens when constructing
+			// this class, because we call "super" before assigning "options", and makeLog is called in super.
+			return super.makeLog(message);
+		} else {
+			return super.makeLog("[" + this.options.width + "/" + this.options.height + "] " + message);
+		}
 	}
 }

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGImage.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGImage.java
@@ -21,8 +21,8 @@ import java.nio.IntBuffer;
 public class DisplayLayerSVGImage extends DisplayLayerImage {
 	private final SVGOptions options;
 
-	public DisplayLayerSVGImage(SVGOptions options, DisplayLayerResources res) {
-		super(options.uri, res);
+	public DisplayLayerSVGImage(SVGOptions options, URI uri, DisplayLayerResources res) {
+		super(uri, res);
 		this.options = options;
 	}
 
@@ -77,6 +77,6 @@ public class DisplayLayerSVGImage extends DisplayLayerImage {
 		}
 	}
 
-	public record SVGOptions(URI uri, float width, float height) {
+	public record SVGOptions(float width, float height) {
 	}
 }

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGImage.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGImage.java
@@ -1,0 +1,82 @@
+package fr.theorozier.webstreamer.display.render;
+
+import com.github.weisj.jsvg.SVGDocument;
+import com.github.weisj.jsvg.geometry.size.FloatSize;
+import com.github.weisj.jsvg.parser.SVGLoader;
+import org.apache.commons.io.IOUtils;
+import org.lwjgl.stb.STBImage;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+public class DisplayLayerSVGImage extends DisplayLayerImage {
+	private final SVGOptions options;
+
+	public DisplayLayerSVGImage(SVGOptions options, DisplayLayerResources res) {
+		super(options.uri, res);
+		this.options = options;
+	}
+
+	@Override
+	protected STBLoadedImage readImageBlocking(InputStream stream) throws IOException {
+		SVGLoader loader = new SVGLoader();
+		SVGDocument svgDocument = loader.load(stream);
+		ByteBuffer buf = null;
+		try {
+			if (svgDocument == null) {
+				throw new IOException("Could not load image: SVG Image is null");
+			}
+
+			// Calculate scaling factors based on block's configured width and height
+			float blockResolution = 512; // block resolution in pixels
+			int blockWidth = (int) (options.width * blockResolution); // Convert blocks to pixels
+			int blockHeight = (int) (options.height * blockResolution); // Convert blocks to pixels
+			FloatSize svgSize = svgDocument.size();
+			float scaleX = blockWidth / svgSize.width;
+			float scaleY = blockHeight / svgSize.height;
+
+			// Convert SVG to Buffered Image
+			BufferedImage image = new BufferedImage(blockWidth, blockHeight, BufferedImage.TYPE_INT_ARGB);
+			Graphics2D g = image.createGraphics();
+			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+			g.scale(scaleX, scaleY); // Apply scaling
+			svgDocument.render(null, g);
+			g.dispose();
+
+			// Convert BufferedImage to byte array
+			ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+			ImageIO.write(image, "png", byteArrayOutputStream);
+			byte[] imageData = byteArrayOutputStream.toByteArray();
+			buf = ByteBuffer.allocateDirect(imageData.length);
+			buf.put(imageData);
+			buf.flip();
+
+			try (MemoryStack memoryStack = MemoryStack.stackPush()){
+				IntBuffer width = memoryStack.mallocInt(1);
+				IntBuffer height = memoryStack.mallocInt(1);
+				IntBuffer channels = memoryStack.mallocInt(1);
+				ByteBuffer stbBuf = STBImage.stbi_load_from_memory(buf, width, height, channels, STBImage.STBI_rgb_alpha);
+				if (stbBuf == null) {
+					throw new IOException("Could not load image: " + STBImage.stbi_failure_reason());
+				}
+				return new STBLoadedImage(stbBuf, width.get(0), height.get(0), channels.get(0));
+			}
+		} finally {
+			MemoryUtil.memFree(buf);
+			IOUtils.closeQuietly(stream);
+		}
+	}
+
+	public record SVGOptions(URI uri, float width, float height) {
+	}
+}

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGMap.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGMap.java
@@ -1,0 +1,33 @@
+package fr.theorozier.webstreamer.display.render;
+
+import org.jetbrains.annotations.NotNull;
+
+public class DisplayLayerSVGMap extends DisplayLayerMap<DisplayLayerSVGImage.SVGOptions> {
+	private final DisplayLayerResources res;
+
+	public DisplayLayerSVGMap(DisplayLayerResources res) {
+		this.res = res;
+	}
+
+	@NotNull
+	@Override
+	protected DisplayLayerSVGImage.SVGOptions getLayerKey(Key key) {
+		return new DisplayLayerSVGImage.SVGOptions(
+			key.uri(),
+			key.display().getWidth(),
+			key.display().getHeight()
+		);
+	}
+
+	@Override
+	protected @NotNull DisplayLayerNode getNewLayer(Key key) throws OutOfLayerException, UnknownFormatException {
+		return new DisplayLayerSVGImage(
+				new DisplayLayerSVGImage.SVGOptions(
+						key.uri(),
+						key.display().getWidth(),
+						key.display().getHeight()
+				),
+				this.res
+		);
+	}
+}

--- a/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGMap.java
+++ b/src/main/java/fr/theorozier/webstreamer/display/render/DisplayLayerSVGMap.java
@@ -13,7 +13,6 @@ public class DisplayLayerSVGMap extends DisplayLayerMap<DisplayLayerSVGImage.SVG
 	@Override
 	protected DisplayLayerSVGImage.SVGOptions getLayerKey(Key key) {
 		return new DisplayLayerSVGImage.SVGOptions(
-			key.uri(),
 			key.display().getWidth(),
 			key.display().getHeight()
 		);
@@ -23,10 +22,10 @@ public class DisplayLayerSVGMap extends DisplayLayerMap<DisplayLayerSVGImage.SVG
 	protected @NotNull DisplayLayerNode getNewLayer(Key key) throws OutOfLayerException, UnknownFormatException {
 		return new DisplayLayerSVGImage(
 				new DisplayLayerSVGImage.SVGOptions(
-						key.uri(),
 						key.display().getWidth(),
 						key.display().getHeight()
 				),
+				key.uri(),
 				this.res
 		);
 	}

--- a/src/main/resources/assets/webstreamer/lang/en_us.json
+++ b/src/main/resources/assets/webstreamer/lang/en_us.json
@@ -6,7 +6,7 @@
   "gui.webstreamer.display.sourceType": "Source type",
   "gui.webstreamer.display.sourceType.raw": "Raw URL",
   "gui.webstreamer.display.sourceType.twitch": "Twitch",
-  "gui.webstreamer.display.url": "URL (.m3u8, .jpeg, .jpg, .bmp, .png)",
+  "gui.webstreamer.display.url": "URL (.m3u8, .jpeg, .jpg, .bmp, .png, .svg)",
   "gui.webstreamer.display.channel": "Channel",
   "gui.webstreamer.display.noQuality": "No quality",
   "gui.webstreamer.display.quality": "Quality",

--- a/src/main/resources/assets/webstreamer/lang/fr_fr.json
+++ b/src/main/resources/assets/webstreamer/lang/fr_fr.json
@@ -6,7 +6,7 @@
   "gui.webstreamer.display.sourceType": "Type de source",
   "gui.webstreamer.display.sourceType.raw": "URL brut",
   "gui.webstreamer.display.sourceType.twitch": "Twitch",
-  "gui.webstreamer.display.url": "URL (.m3u8, .jpeg, .jpg, .bmp, .png)",
+  "gui.webstreamer.display.url": "URL (.m3u8, .jpeg, .jpg, .bmp, .png, .svg)",
   "gui.webstreamer.display.channel": "Chaîne",
   "gui.webstreamer.display.noQuality": "Pas de qualité",
   "gui.webstreamer.display.quality": "Qualité",


### PR DESCRIPTION
When I tried to run my SVG code from the IDE - everything worked since the IDE loads all dependencies via Gradle. However, when I tried to run this mod on a stand-alone Minecraft the following error was produced:

```
[DisplayLayerSVGImage:C99A6B42] [4.0/2.5] Failed to request image, retrying in 30 seconds.
java.lang.NoClassDefFoundError: com/github/weisj/jsvg/parser/SVGLoader
	at fr.theorozier.webstreamer.display.render.DisplayLayerSVGImage.readImageBlocking(DisplayLayerSVGImage.java:31)
	at fr.theorozier.webstreamer.display.render.DisplayLayerImage.requestImageBlocking(DisplayLayerImage.java:86)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: com.github.weisj.jsvg.parser.SVGLoader
	... 6 more
```

This error was produced because the JSVG library was not included in the jar - this is now fixed by using `include "com.github.weisj:jsvg:${project.jsvg_parser}"` inside "build.gradle".

GitHub might say there are more than 1 commits - these are from the other PR.